### PR TITLE
Fixed Formatting in markdown files

### DIFF
--- a/MeetingDocs/Sprint0/StandupDec30.md
+++ b/MeetingDocs/Sprint0/StandupDec30.md
@@ -2,8 +2,11 @@
 
 ## Updates
 
-Kobe - set up the project folder. Set up the front end using vite. Currently working on developing 
-the database ER Diagram. Set up the environment such that it is ready to use.
+- Kobe
+ - set up the project folder. 
+ - Set up the front end using vite.
+ - Currently working on developing the database ER Diagram. 
+ - Set up the environment such that it is ready to use.
 
 ## Challenges 
 

--- a/MeetingDocs/Sprint0/StandupDec30.md
+++ b/MeetingDocs/Sprint0/StandupDec30.md
@@ -3,10 +3,10 @@
 ## Updates
 
 - Kobe
- - set up the project folder. 
- - Set up the front end using vite.
- - Currently working on developing the database ER Diagram. 
- - Set up the environment such that it is ready to use.
+  - set up the project folder. 
+  - Set up the front end using vite.
+  - Currently working on developing the database ER Diagram. 
+  - Set up the environment such that it is ready to use.
 
 ## Challenges 
 

--- a/MeetingDocs/Sprint0/StandupDec31.md
+++ b/MeetingDocs/Sprint0/StandupDec31.md
@@ -3,21 +3,21 @@
 ## Updates 
 
 - **General**
- - Sprint Meetings time needs to be rediscussed 
- - MVP needs to be demo ready by Sprint 2 
+  - Sprint Meetings time needs to be rediscussed 
+  - MVP needs to be demo ready by Sprint 2 
 
 - Kobe
- - working on the Databse Design Document and corresponding ER Diagram
- - redefining the spec for the MVP
+  - working on the Databse Design Document and corresponding ER Diagram
+  - redefining the spec for the MVP
 
 - Ben
- - N/A
+  - N/A
 
 - Drew
- - N/A
+  - N/A
 
 - Carter
- - N/A
+  - N/A
 
 ## Challenges
 

--- a/MeetingDocs/Sprint0/StandupJan1.md
+++ b/MeetingDocs/Sprint0/StandupJan1.md
@@ -3,17 +3,17 @@
 ## Updates
 
 - General
- - 1 month confirmed for new MVP
+  - 1 month confirmed for new MVP
 
 - Kobe
- - Finished the Databse Design 
- - ER Diagram 
+  - Finished the Databse Design 
+  - ER Diagram 
 
 - Ben 
- - N/A 
+  - N/A 
 
 - Drew
- - N/A
+  - N/A
 
 ## Challenges
 

--- a/MeetingDocs/Sprint0/StandupJan3.md
+++ b/MeetingDocs/Sprint0/StandupJan3.md
@@ -2,20 +2,20 @@
 
 ## Updates
 - General
- - Starting today sprint meetings have changed times
-  - **Stand up Meetings:** 8:00am M-F
-  - **Sprint Planning Meeetings:** 3:00pm Thurs
+  - Starting today sprint meetings have changed times
+    - **Stand up Meetings:** 8:00am M-F
+    - **Sprint Planning Meeetings:** 3:00pm Thurs
 
 - Kobe
- - Created Logo
- - Almost done with Home Page Figma Design
- - Will work on setting up database
+  - Created Logo
+  - Almost done with Home Page Figma Design
+  - Will work on setting up database
 
 - Carter
- - Created Figma Team
+  - Created Figma Team
 
 - Drew
- - Will start on backend API function signup
+  - Will start on backend API function signup
 
 ## New Tasks
 

--- a/MeetingDocs/Sprint0/StandupJan6.md
+++ b/MeetingDocs/Sprint0/StandupJan6.md
@@ -1,0 +1,20 @@
+# Meeting Notes
+
+## Updates
+
+- Kobe
+  - Redesigning database to account for availabilty
+
+- Drew
+  - Researching python flask for endpoint creation
+
+- Ben
+  - Creating the GUI for the frontend
+
+## Challenges
+
+- Endpoints creation is blocked by current database tasks
+
+## New Tasks
+
+## Additional Tasks

--- a/MeetingDocs/Sprint0/StandupJan7.md
+++ b/MeetingDocs/Sprint0/StandupJan7.md
@@ -1,0 +1,26 @@
+# Meetings Notes
+
+## Updates
+
+- Kobe
+  - Working on fixing the Virtual Machine
+  - Creating the Database
+
+- Carter
+  - Figma Designs for the Login and Sign Up Pages 
+
+- Ben 
+  - N/A
+
+- Drew
+  - N/A
+
+## Challenges
+
+- Backend tasks are blocked by not having a database
+
+## New Tasks
+
+- Create Notes for Designs of Pages that need completion after the sign up and home pages. 
+
+## Additional Notes


### PR DESCRIPTION
The markdown files (especially the ones for in the meetingNotes/Sprint0 folder) had improperly formatted bullet lists. I fixed the whitespace, so that the files were more cohesive.